### PR TITLE
Bug fix: deleting a child-prent relationship doesn't remove data from…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
 
 ## v0.6.3
-Bug fix: preloading `has_one` association should not return a list.
+Bug fix: preloading `has_one` association should not return a list.  
+  
+## v0.6.4
+Bug fix: updating `has_one` and `belongs_to` assocation doesn't work properly.  
+  
+## v0.6.5
+Bug fix: adding a new relationship doesn't set the new relationship data.  
+  
+## v0.6.6
+Bug fix: deleting a realtionship in a `belongs_to` association doesn't remove realtionship data from struct.  

--- a/lib/ecto_neo4j/adapter.ex
+++ b/lib/ecto_neo4j/adapter.ex
@@ -123,8 +123,22 @@ defmodule Ecto.Adapters.Neo4j do
             final_data =
               case schema.__schema__(:association, field) do
                 %Ecto.Association.BelongsTo{owner_key: foreign_key} ->
+                  schema_name =
+                    schema
+                    |> Module.split()
+                    |> List.last()
+                    |> String.downcase()
+
+                  rel_type =
+                    field
+                    |> Atom.to_string()
+                    |> String.replace("_" <> schema_name, "")
+
+                  rel_data_key = ("rel_" <> rel_type) |> String.to_atom()
+
                   updated_data
                   |> Map.put(foreign_key, nil)
+                  |> Map.put(rel_data_key, nil)
 
                 _ ->
                   updated_data

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EctoNeo4j.MixProject do
     [
       name: "EctoNeo4j",
       app: :ecto_neo4j,
-      version: "0.6.4",
+      version: "0.6.6",
       elixir: "~> 1.8",
       package: package(),
       description: "Ecto adapter for Neo4j graph database",

--- a/test/ecto_neo4j/relationships_test.exs
+++ b/test/ecto_neo4j/relationships_test.exs
@@ -638,7 +638,7 @@ defmodule EctoNeo4j.RelationshipsTest do
                 },
                 has_comment_uuid: "ae830851-9e93-46d5-bbf7-23ab99846497",
                 rel_has: %{},
-                rel_wrote: %{"when" => ~D[2018-06-18]},
+                rel_wrote: nil,
                 text: "This a comment from john Doe",
                 uuid: "2be39329-d9b5-4b85-a07f-ee9a2997a8ef",
                 wrote_comment: nil,
@@ -1082,6 +1082,28 @@ defmodule EctoNeo4j.RelationshipsTest do
 
       assert %Bolt.Sips.Response{results: [%{"nb_rel" => 1}]} =
                Ecto.Adapters.Neo4j.query!(cql_check, params)
+    end
+
+    test "bug fix: wrong data when relationship is deleted (child->  parent)" do
+      user_data = add_data()
+
+      post = List.first(user_data.wrote_post)
+
+      assert %EctoNeo4j.Integration.Post{
+               read_post_uuid: nil,
+               rel_read: nil,
+               rel_wrote: nil,
+               text: "This is the first",
+               title: "First",
+               uuid: "ae830851-9e93-46d5-bbf7-23ab99846497",
+               wrote_post: nil,
+               wrote_post_uuid: nil
+             } =
+               TestRepo.get!(Post, post.uuid)
+               |> Ecto.Adapters.Neo4j.preload(:wrote_post)
+               |> Ecto.Changeset.change()
+               |> Ecto.Changeset.put_assoc(:wrote_post, nil)
+               |> Ecto.Adapters.Neo4j.update!(TestRepo)
     end
   end
 


### PR DESCRIPTION
When deleting a `belongs_to` association from child, the relationship data are not remove from struct.